### PR TITLE
iNES directives

### DIFF
--- a/asm6f.c
+++ b/asm6f.c
@@ -91,6 +91,18 @@ label firstlabel={		  //'$' label
 typedef unsigned char byte;
 typedef void (*icfn)(label*,char**);
 
+//[nicklausw] ines stuff
+int ines_include = 0;
+int inesprg_num  = 0;
+int ineschr_num  = 0;
+int inesmir_num  = 0;
+int inesmap_num  = 0;
+
+void inesprg(label*, char**);
+void ineschr(label*, char**);
+void inesmir(label*, char**);
+void inesmap(label*, char**);
+
 label *findlabel(char*);
 void initlabels();
 label *newlabel();
@@ -363,6 +375,10 @@ struct {
 		"DL",dl,
 		"DH",dh,
 		"ERROR",make_error,
+		"INESPRG",inesprg,
+        "INESCHR",ineschr,
+        "INESMIR",inesmir,
+        "INESMAP",inesmap,
 		0, 0
 };
 
@@ -1709,6 +1725,13 @@ void output(byte *p,int size) {
 			errmsg="Can't create output file.";
 			return;
 		}
+
+        // (insert iNES if needed)
+        if (ines_include) {
+            byte ineshdr[16] = {'N','E','S',0x1A,(byte)inesprg_num, (byte)ineschr_num, (byte)(inesmap_num << 4) | inesmir_num, (byte)inesmap_num & 0xF0,0,0,0,0,0,0,0,0};
+            if ( fwrite(ineshdr,1,16,outputfile) < (size_t)16 || fflush( outputfile ) )
+                errmsg="Write error.";
+        }
 	}
 	if(!outputfile) return;
 	while(size--) {
@@ -2406,4 +2429,26 @@ void make_error(label *id,char **next) {
 	errmsg=s;
 	error=1;
 	*next=s+strlen(s);
+}
+
+//[nicklausw] ines stuff
+
+void inesprg(label *id, char **next) {
+    inesprg_num=eval(next, WHOLEEXP);
+    ines_include++;
+}
+
+void ineschr(label *id, char **next) {
+    ineschr_num=eval(next, WHOLEEXP);
+    ines_include++;
+}
+
+void inesmir(label *id, char **next) {
+    inesmir_num=eval(next, WHOLEEXP);
+    ines_include++;
+}
+
+void inesmap(label *id, char **next) {
+    inesmap_num=eval(next, WHOLEEXP);
+    ines_include++;
 }

--- a/asm6f.c
+++ b/asm6f.c
@@ -376,9 +376,9 @@ struct {
 		"DH",dh,
 		"ERROR",make_error,
 		"INESPRG",inesprg,
-        "INESCHR",ineschr,
-        "INESMIR",inesmir,
-        "INESMAP",inesmap,
+		"INESCHR",ineschr,
+		"INESMIR",inesmir,
+		"INESMAP",inesmap,
 		0, 0
 };
 
@@ -1395,7 +1395,7 @@ void processfile(FILE *f, char* name) {
 			errmsg=NoENDE;
 		// [freem addition]
 		if(nonl)
-            errmsg=NoENDINL;
+			errmsg=NoENDINL;
 		if(errmsg)
 			showerror(name,nline);
 	}
@@ -1726,12 +1726,12 @@ void output(byte *p,int size) {
 			return;
 		}
 
-        // (insert iNES if needed)
-        if (ines_include) {
-            byte ineshdr[16] = {'N','E','S',0x1A,(byte)inesprg_num, (byte)ineschr_num, (byte)(inesmap_num << 4) | inesmir_num, (byte)inesmap_num & 0xF0,0,0,0,0,0,0,0,0};
-            if ( fwrite(ineshdr,1,16,outputfile) < (size_t)16 || fflush( outputfile ) )
-                errmsg="Write error.";
-        }
+		// (insert iNES if needed)
+		if (ines_include) {
+			byte ineshdr[16] = {'N','E','S',0x1A,(byte)inesprg_num, (byte)ineschr_num, (byte)(inesmap_num << 4) | inesmir_num, (byte)inesmap_num & 0xF0,0,0,0,0,0,0,0,0};
+			if ( fwrite(ineshdr,1,16,outputfile) < (size_t)16 || fflush( outputfile ) )
+				errmsg="Write error.";
+		}
 	}
 	if(!outputfile) return;
 	while(size--) {
@@ -2434,21 +2434,21 @@ void make_error(label *id,char **next) {
 //[nicklausw] ines stuff
 
 void inesprg(label *id, char **next) {
-    inesprg_num=eval(next, WHOLEEXP);
-    ines_include++;
+	inesprg_num=eval(next, WHOLEEXP);
+	ines_include++;
 }
 
 void ineschr(label *id, char **next) {
-    ineschr_num=eval(next, WHOLEEXP);
-    ines_include++;
+	ineschr_num=eval(next, WHOLEEXP);
+	ines_include++;
 }
 
 void inesmir(label *id, char **next) {
-    inesmir_num=eval(next, WHOLEEXP);
-    ines_include++;
+	inesmir_num=eval(next, WHOLEEXP);
+	ines_include++;
 }
 
 void inesmap(label *id, char **next) {
-    inesmap_num=eval(next, WHOLEEXP);
-    ines_include++;
+	inesmap_num=eval(next, WHOLEEXP);
+	ines_include++;
 }


### PR DESCRIPTION
Inserts header automatically, unlike asm6n. INESINS and -i don't exist because they don't have to. :smile: 

Problems:

- Not sure if the header is inserted when only one pass is given. (update, :white_check_mark: it is)
- No edits to readme, chances are I'll put things exactly where you don't want them.
- No iNES 2.0 just yet.

How's things look thus far?
