### PR TITLE
CDL & Mesen label exports

### DIFF
--- a/asm6f.c
+++ b/asm6f.c
@@ -1232,22 +1232,26 @@ void export_lua() {
 	fclose ( mainfile );
 }
 
-int comparelabels(const label** a, const label** b)
+int comparelabels(const void* arg1, const void* arg2)
 {
-	if((*a)->type > (*b)->type) return 1;
-	if((*a)->type < (*b)->type) return -1;
-	if((*a)->pos > (*b)->pos) return 1;
-	if((*a)->pos < (*b)->pos) return -1;
-	if((*a)->value > (*b)->value) return 1;
-	if((*a)->value < (*b)->value) return -1;
-	return strcmp((*a)->name, (*b)->name);
+	const label* a = *((label**)arg1);
+	const label* b = *((label**)arg2);
+	if(a->type > b->type) return 1;
+	if(a->type < b->type) return -1;
+	if(a->pos > b->pos) return 1;
+	if(a->pos < b->pos) return -1;
+	if(a->value > b->value) return 1;
+	if(a->value < b->value) return -1;
+	return strcmp(a->name, b->name);
 }
 
-int comparecomments(const comment** a, const comment** b)
+int comparecomments(const void* arg1, const void* arg2)
 {
-	if((*a)->pos > (*b)->pos) return 1;
-	if((*a)->pos < (*b)->pos) return -1;
-	return strcmp((*a)->text, (*b)->text);
+	const comment* a = *((comment**)arg1);
+	const comment* b = *((comment**)arg2);
+	if(a->pos > b->pos) return 1;
+	if(a->pos < b->pos) return -1;
+	return strcmp(a->text, b->text);
 }
 
 void export_mesenlabels() {
@@ -1995,7 +1999,8 @@ void output(byte *p,int size, int cdlflag) {
 			while(repeat--) {
 				if(addr < 0x10000) {
 					//PRG, mark as either code or data
-					fwrite((void*)&((byte)cdlflag), 1, 1, cdlfile);
+					byte flag = (byte)cdlflag;
+					fwrite((void*)&flag, 1, 1, cdlfile);
 				} else {
 					//CHR data
 					fwrite("\x0", 1, 1, cdlfile);

--- a/asm6f.c
+++ b/asm6f.c
@@ -1783,6 +1783,8 @@ void showhelp(void) {
 	// [freem addition]
 	puts("\t-n\t\texport FCEUX-compatible .nl files");
 	puts("\t-f\t\texport Lua symbol file\n");
+	puts("\t-c\t\texport .cdl for use with FCEUX/Mesen");
+	puts("\t-n\t\texport Mesen-compatible label file (.mlb)");
 	puts("See README.TXT for more info.\n");
 }
 

--- a/asm6f.c
+++ b/asm6f.c
@@ -1784,7 +1784,7 @@ void showhelp(void) {
 	puts("\t-n\t\texport FCEUX-compatible .nl files");
 	puts("\t-f\t\texport Lua symbol file\n");
 	puts("\t-c\t\texport .cdl for use with FCEUX/Mesen");
-	puts("\t-n\t\texport Mesen-compatible label file (.mlb)");
+	puts("\t-m\t\texport Mesen-compatible label file (.mlb)");
 	puts("See README.TXT for more info.\n");
 }
 


### PR DESCRIPTION
Adds a -c switch to export CDL files
Adds a -m switch to export labels in .mlb files

Let me know if you see anything that needs to be changed.
One thing that might be useful that I didn't do would be to respect the "ignorenl" flag for the .mlb export, too.