### PR TITLE
Added .lst file creation directives

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 --------------------------------------------------------------
 ASM6f (v1.6)
 A 6502 assembler by loopy (loopy at mm.st)
-With modifications by freem, nicklausw, and Sour
+With modifications by freem, nicklausw, Sour, and unregistered
 --------------------------------------------------------------
 
 ASM6f is a fork of ASM6, primarily targeted at NES/Famicom development.
@@ -38,6 +38,9 @@ Options:
         -f         export Lua symbol file
         -c         export .cdl for use with FCEUX/Mesen
         -m         export Mesen-compatible label file (.mlb)
+        -u         Create unreg listing (contracts rept; expands MACRO)
+        -U         Create cool listing (expands only MACRO use and hides their definitions)
+
         Default output is <sourcefile>.bin
         Default listing is <sourcefile>.lst
 


### PR DESCRIPTION
- -u
- -U
>        -L         Create verbose listing (expand REPT, MACRO)

-u will only expand macros (rept definitions are shown)... reduces .lst file size

	 (without -U directive, -u keeps macro definitions shown)

-U will ONLY expand macro use; hides macro definitions and also runs -u flag

---
line 1687 is major change that runs listline depending on 5 flags

	that line is simplified with boolean algebra :)

Note: running asm6f with all the listing flags will cause a -L lst file to be created, like Loopy's original design :)

	  all lines we edited end with 0_0
			except: the 4 variables we created at the end of the variable list
					and line 1687... sorry.

	  we is God, my heavenly father, and me :)


p.s. Koitsu encouraged me to submit these changes to your asm6f