### PR TITLE
Labels: Fixed file position information for labels when using "enum"

### DIFF
--- a/asm6f.c
+++ b/asm6f.c
@@ -2021,7 +2021,6 @@ void output(byte *p,int size, int cdlflag) {
 	}
 
 	addr+=size;
-	filepos+=size;
 
 	if(nooutput)
 		return;
@@ -2029,6 +2028,7 @@ void output(byte *p,int size, int cdlflag) {
 		oldpass=pass;
 		if(outputfile) fclose(outputfile);
 		outputfile=fopen(outputfilename,"wb");
+		filepos=0;
 		outcount=0;
 		if(!outputfile) {
 			errmsg="Can't create output file.";
@@ -2050,6 +2050,7 @@ void output(byte *p,int size, int cdlflag) {
 								0,0,0};
 			if ( fwrite(ineshdr,1,16,outputfile) < (size_t)16 || fflush( outputfile ) )
 				errmsg="Write error.";
+			filepos += 16;
 		}
 	}
 	if(!outputfile) return;
@@ -2057,6 +2058,7 @@ void output(byte *p,int size, int cdlflag) {
 		if(listfile && listcount<LISTMAX)
 			listbuff[listcount]=*p;
 		listcount++;
+		filepos++;
 		outputbuff[outcount++]=*p;
 		p++;
 		if(outcount>=BUFFSIZE) {


### PR DESCRIPTION
This fixes a bug tepples found yesterday.

The "nooutput" flag is true inside an "enum", which desyncs the value of filepos from the actual offset in the file.  Ended up with the file position for a label at the first byte of PRG ROM being set to 23 instead of 16 (because the source had 7 bytes worth of enum declaractions before the actual code began).

Also fixed what looks like a bug when ines_include is enabled (filepos wasn't incremented to match), but that bit is untested.