### PR TITLE
Patching directives

### DIFF
--- a/asm6f.c
+++ b/asm6f.c
@@ -2646,7 +2646,7 @@ void output(byte *p,int size, int cdlflag) {
 	if (nooutput)
 		return;
 	
-	if(!outputfile || !genips) return;
+	if(!outputfile && !genips) return;
 	
 	// write data.
 	output_buffer(p, size);

--- a/asm6f.c
+++ b/asm6f.c
@@ -2523,7 +2523,7 @@ void output_buffer(byte* p, size_t count)
 		// compare
 		if (comparefiller)
 		{
-			int b = get_cmp_value(filepos + outcount);
+			int b = get_cmp_value(filepos + i);
 			if (b != defaultfiller && b >= 0)
 			{
 				errmsg = CompFailed;

--- a/readme.txt
+++ b/readme.txt
@@ -218,10 +218,15 @@ INCNES
     Includes the given NES file in its entirety, reading its header.
     Fatal error if the header is invalid.
     
-    Identical to:
+    Similar to using both of the following commands:
     
         INCINES "file.nes"
-        INCBIN "file.nes", $10    
+        INCBIN "file.nes", $10
+        
+    However, if a CDL file (i.e. "file.cdl") exists with the same
+    basename as as the included .nes file, then that CDL data will
+    be used. Otherwise, the CDL data is set to NONE. See the .c flag
+    for details.
 
 SEEKABS x
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,8 @@ With modifications by freem, nicklausw, and Sour
 
 ASM6f is a fork of ASM6, primarily targeted at NES/Famicom development.
 
+See readme-original.txt for the features of ASM6.
+
 --------------------------------------------------------------
 Features compared to stock ASM6
 --------------------------------------------------------------
@@ -211,6 +213,47 @@ HUNSTABLE
                 HUNSTABLE
                 xaa #7
 
+INCNES
+    
+    Includes the given NES file in its entirety, reading its header.
+    Fatal error if the header is invalid.
+    
+    Identical to:
+    
+        INCINES "file.nes"
+        INCBIN "file.nes", $10    
+
+SEEKABS x
+
+    Sets the output position in the file. This permits
+    overwriting data or code that was previously written.
+    
+    When seeking past the end of the file, the file will be padded
+    up to the seek point.
+    
+    The program address ($) is not modified by this directive.
+    
+SEEKREL x
+
+    As above, but relative to the current output location.
+    
+    The program address ($) is not modified by this directive.
+    
+SKIPREL x
+
+    Skips x bytes without writing -- though padding will be used if skipping
+    past the end of the file.
+    
+    The file position and program address are both modified by this directive.
+    
+    There is no SKIPABS directive because the program address ($) and file output
+    location are not co-absolute; they may be offset from each other and need not agree.
+    
+    Identical to:
+    
+        SEEKREL x
+        BASE $+x
+
 --------------------------------------------------------------
 iNES directives
 --------------------------------------------------------------
@@ -250,6 +293,11 @@ NES2BRAM x
 
 NES2CHRBRAM x
         Amount of battery-packed CHR RAM in NES ROM.
+        
+INCINES file.nes
+    Reads the nes header from the given binary file.
+    Reads both iNES and NES2 headers.
+    Fatal error if the header is invalid.
 
 --------------------------------------------------------------
 loopy's original To-Do List

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ Options:
         -f         export Lua symbol file
         -c         export .cdl for use with FCEUX/Mesen
         -m         export Mesen-compatible label file (.mlb)
+        -i         build .ips patch file instead of binary output.
         Default output is <sourcefile>.bin
         Default listing is <sourcefile>.lst
 
@@ -258,6 +259,22 @@ SKIPREL x
     
         SEEKREL x
         BASE $+x
+
+COMPARE / ENDCOMPARE
+    
+    when enabled, every byte that overwrites a previously written byte
+    will be compared to the current fillvalue (see FILLVALUE), and if
+    they differ, a fatal error will be thrown.
+    
+    This is useful, for example, to assert that one doesn't overwrite
+    any important data while patching.
+        
+CLEARPATCH
+
+    Clears all data written so far in the .ips patch.
+    You can use this to specify that the previous data written is not part of the patch.
+    This is ignored when the -i flag is not used.
+
 
 --------------------------------------------------------------
 iNES directives


### PR DESCRIPTION
I've added a few new directives which should help when making hacks or patches:

- Can now parse a header from an existing .nes file with `INCINES`, or import the .nes file (header and all) with `INCNES`

- Can seek to any arbitrary location (e.g. within an already-included binary file) to edit with `SEEKABS x`, `SEEKREL x`, and `SKIPREL x` (the lattermost also updates `addr` aka `$`) This allows jumping to locations without filling the bytes in-between.

The use case for these is that one might have an already-compiled .nes file that one wants to create a patch for, i.e. edit a particular part of the file (then use another program to generate a binary diff to create the patch like a .ips file. Perhaps in a future PR, .ips exporting can be done by asm6f directly?).

Since this is a new feature different from previous ones, I've updated the version number.

#### Bugfixes

- Fixed some .nl addresses when $ is unset.

- Fixed a couple bugs related to the ines/nes2 header. This was the biggest, located in the `output` function:

Before:
```
(byte)(inesmap_num & 0xF0) | (use_nes2 << 3) | (nes2tv_num << 7)
```

After
```
(byte)(inesmap_num & 0xF0) | (use_nes2 << 3) | (nes2vs_num)
```
the << 7 after nes2tv_num seems to be erroneous, so I removed that. On consulting the specifications, it seems that `nes2vs_num` should be there instead. (Previously, `nes2vs_num` was not output anywhere.)

#### Misc

- cleaned up the `output` function, breaking it down into a couple different functions (`output`, `output_file` (which generates the output file if needed on a new pass), and `flush_output` (writes the current output buffer to the file))
- extracted common pattern to replace file extension into its own functions, `replace_ext` and `find_ext`.
- added a couple comments to the code.