### PR TITLE
INCBIN/BIN: show error if fread() results in a short read

### DIFF
--- a/asm6f.c
+++ b/asm6f.c
@@ -440,6 +440,7 @@ char DivZero[]="Divide by zero.";
 char BadAddr[]="Can't determine address.";
 char NeedName[]="Need a name.";
 char CantOpen[]="Can't open file.";
+char CantRead[]="Can't read file (possible I/O error).";
 char ExtraENDM[]="ENDM without MACRO.";
 char ExtraENDR[]="ENDR without REPT.";
 char ExtraENDE[]="ENDE without ENUM.";
@@ -2203,7 +2204,8 @@ void include(label *id,char **next) {
 }
 
 void incbin(label *id,char **next) {
-	int filesize, seekpos, bytesleft, i;
+	int filesize, seekpos, bytesleft;
+	size_t i;
 	FILE *f=0;
 
 	do {
@@ -2236,7 +2238,10 @@ void incbin(label *id,char **next) {
 		while(bytesleft) {
 			if(bytesleft>BUFFSIZE) i=BUFFSIZE;
 			else i=bytesleft;
-			fread(inputbuff,1,i,f);
+			if (fread(inputbuff,1,i,f) != i) {
+				errmsg=CantRead;
+				break;
+			}
 			output(inputbuff,i,DATA);
 			bytesleft-=i;
 		}


### PR DESCRIPTION
This code might look odd at first glance, especially since in other software, `fread()` returning less bytes than asked for can be normal when near EOF.  In asm6's case, the size is calculated in real-time.

Note: this may or may not conflict with PR https://github.com/freem/asm6f/pull/33 (I would merge that one first).