### PR TITLE
Support for newer/older style Mesen (.MLB) label export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.obj
 asm6f
 test_cases/incbin/incbin.bin
+compile.bat

--- a/asm6f.c
+++ b/asm6f.c
@@ -1,7 +1,7 @@
 /* asm6f - asm6 with modifications for NES/Famicom development */
 
 /*  asm6f History:
-1.6 + Knuckles
+1.6 + f003
 	* [controllerhead] Added support for newer/older Mesen-compatible (.mlb) label export.
 	
 1.6 + f002

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,8 @@ Options:
         -n         export FCEUX-compatible .nl files
         -f         export Lua symbol file
         -c         export .cdl for use with FCEUX/Mesen
-        -m         export Mesen-compatible label file (.mlb)
+        -m         export new style Mesen-compatible label file (.mlb)
+				-M         export old style Mesen-compatible label file (.mlb)
         Default output is <sourcefile>.bin
         Default listing is <sourcefile>.lst
 

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ Options:
         -f         export Lua symbol file
         -c         export .cdl for use with FCEUX/Mesen
         -m         export new style Mesen-compatible label file (.mlb)
-				-M         export old style Mesen-compatible label file (.mlb)
+        -M         export old Mesen-compatible label file (.mlb)
         Default output is <sourcefile>.bin
         Default listing is <sourcefile>.lst
 


### PR DESCRIPTION
Sour has updated the Mesen label (.MLB) format, you can now export both the newer/older style:
-m for new style labels
-M for old style labels