### PR TITLE
Fix unnecessary ptrdiff_t force-casts

### DIFF
--- a/asm6f.c
+++ b/asm6f.c
@@ -2583,7 +2583,7 @@ void ifdef(label *id,char **next) {
 	else
 		iflevel++;
 	getlabel(s,next);
-	skipline[iflevel]=!(ptrdiff_t)findlabel(s) || skipline[iflevel-1];
+	skipline[iflevel]=!findlabel(s) || skipline[iflevel-1];
 	ifdone[iflevel]=!skipline[iflevel];
 }
 
@@ -2594,7 +2594,7 @@ void ifndef(label *id,char **next) {
 	else
 		iflevel++;
 	getlabel(s,next);
-	skipline[iflevel]=(ptrdiff_t)findlabel(s) || skipline[iflevel-1];
+	skipline[iflevel]=findlabel(s) || skipline[iflevel-1];
 	ifdone[iflevel]=!skipline[iflevel];
 }
 


### PR DESCRIPTION
Examples:
```
asm6f.c: In function ‘ifdef’:
asm6f.c:2586:28: error: cast from function call of type ‘label *’ to non-matching type ‘long int’ [-Werror=bad-function-cast]
 2586 |         skipline[iflevel]=!(ptrdiff_t)findlabel(s) || skipline[iflevel-1];
      |                            ^
asm6f.c: In function ‘ifndef’:
asm6f.c:2597:27: error: cast from function call of type ‘label *’ to non-matching type ‘long int’ [-Werror=bad-function-cast]
 2597 |         skipline[iflevel]=(ptrdiff_t)findlabel(s) || skipline[iflevel-1];
      |                           ^
```