### PR TITLE
Fix implicit fallthrough warnings

### DIFF
--- a/asm6f.c
+++ b/asm6f.c
@@ -801,7 +801,7 @@ int getoperator(char **str) {
 				(*str)++;
 				return NOTEQUAL;
 			}
-			//(to default)
+			// fall through
 		default:
 			(*str)--;
 			return NOOP;
@@ -1879,6 +1879,7 @@ int main(int argc,char **argv) {
 					return EXIT_FAILURE;
 				case 'L':
 					verboselisting=1;
+					break;
 				case 'l':
 					listfilename=true_ptr;
 					break;


### PR DESCRIPTION
The situation with `main()` appears to be a simple bug: a missing `break`.

The situation with `getoperator()` is different: it has an implicit fallthrough into `default`).  One can placate GCC using a special C/C++-style comment of `fall through` immediately following the `}`.  Sadly, `__attribute__ ((fallthrough))` is not portable (for Clang etc.).  For details see SO post https://stackoverflow.com/a/45137452 .

Examples:
```
asm6f.c: In function ‘getoperator’:
asm6f.c:800:27: error: this statement may fall through [-Werror=implicit-fallthrough=]
  800 |                         if(**str=='=') {
      |                           ^
asm6f.c:805:17: note: here
  805 |                 default:
      |                 ^~~~~~~
asm6f.c: In function ‘main’:
asm6f.c:1881:55: error: this statement may fall through [-Werror=implicit-fallthrough=]
 1881 |                                         verboselisting=1;
      |                                         ~~~~~~~~~~~~~~^~
asm6f.c:1882:33: note: here
 1882 |                                 case 'l':
      |                                 ^~~~

```