### PR TITLE
Fix maybe uninitialized warnings (actual bugs)

### DIFF
--- a/asm6f.c
+++ b/asm6f.c
@@ -1190,7 +1190,7 @@ void export_labelfiles() {
 
 	strptr=strrchr(filename,'.'); // strptr ='.'ptr
 	if(strptr) if(strchr( strptr,'\\' )) strptr = 0; // watch out for "dirname.ext\listfile"
-	if(!strptr) strptr = filename + strlen(str); // strptr -> inputfile extension
+	if(!strptr) strptr = filename + strlen(filename); // strptr -> inputfile extension
 	strcpy(strptr, ".nes.ram.nl");
 
 	ramfile=fopen(filename, "w");
@@ -1259,7 +1259,7 @@ void export_lua() {
 
 	strptr=strrchr(filename,'.'); // strptr ='.'ptr
 	if(strptr) if(strchr( strptr,'\\' )) strptr = 0; // watch out for "dirname.ext\listfile"
-	if(!strptr) strptr = filename + strlen(str); // strptr -> inputfile extension
+	if(!strptr) strptr = filename + strlen(filename); // strptr -> inputfile extension
 	strcpy(strptr, ".lua");
 
 	mainfile=fopen(filename, "w");


### PR DESCRIPTION
While going through a code review, I found that functions `export_labelfiles()` and `export_lua()` both seem to call `strlen(str)` -- which is uninitialised -- instead of `strlen(filename)` like in `export_mesenlabels()`.  This looks to be a bug in original asm6.

Examples:
```
asm6f.c: In function ‘export_labelfiles’:
asm6f.c:1193:41: error: ‘str’ may be used uninitialized [-Werror=maybe-uninitialized]
 1193 |         if(!strptr) strptr = filename + strlen(str); // strptr -> inputfile extension
      |                                         ^~~~~~~~~~~
In file included from asm6f.c:45:
/usr/include/string.h:41:10: note: by argument 1 of type ‘const char *’ to ‘strlen’ declared here
   41 | size_t   strlen (const char *);
      |          ^~~~~~
asm6f.c:1178:14: note: ‘str’ declared here
 1178 |         char str[LINEMAX];
      |              ^~~
asm6f.c: In function ‘export_lua’:
asm6f.c:1262:41: error: ‘str’ may be used uninitialized [-Werror=maybe-uninitialized]
 1262 |         if(!strptr) strptr = filename + strlen(str); // strptr -> inputfile extension
      |                                         ^~~~~~~~~~~
In file included from asm6f.c:45:
/usr/include/string.h:41:10: note: by argument 1 of type ‘const char *’ to ‘strlen’ declared here
   41 | size_t   strlen (const char *);
      |          ^~~~~~
asm6f.c:1253:14: note: ‘str’ declared here
 1253 |         char str[LINEMAX];
      |              ^~~
```