### PR TITLE
Fix cast align warnings

### DIFF
--- a/asm6f.c
+++ b/asm6f.c
@@ -196,6 +196,7 @@ void expandrept(int,char*);
 void make_error(label*,char**);
 void unstable(label*,char**);
 void hunstable(label*,char**);
+void *my_malloc(size_t);
 char *my_strupr(char*);
 int hexify(int);
 char *strend(char*,char*);
@@ -572,7 +573,7 @@ static void message( const char fmt [], ... )
 }
 
 // Same as malloc(), but prints error and exits if allocation fails
-static char* my_malloc( size_t s )
+void* my_malloc( size_t s )
 {
 	char* p = malloc( s ? s : 1 );
 	if ( p == NULL )
@@ -1761,7 +1762,7 @@ void processline(char *src,char *errsrc,int errline) {
 				if(comment)
 					strcat(line,comment);	   //keep comment for listing
 				*makemacro=my_malloc(strlen(line)+sizeof(char*)+1);
-				makemacro=(char**)*makemacro;
+				makemacro=(void*)*makemacro;
 				*makemacro=0;
 				strcpy((char*)&makemacro[1],line);
 			}
@@ -1793,7 +1794,7 @@ void processline(char *src,char *errsrc,int errline) {
 				if(comment)
 					strcat(line,comment);	   //keep comment for listing
 				*makerept=my_malloc(strlen(line)+sizeof(char*)+1);
-				makerept=(char**)*makerept;
+				makerept=(void*)*makerept;
 				*makerept=0;
 				strcpy((char*)&makerept[1],line);
 			}
@@ -2665,7 +2666,7 @@ void macro(label *id, char **next) {
 		while(getlabel(word,&src)) {//don't affect **next directly, make sure it's a good name first
 			*next=src;
 			*makemacro=my_malloc(strlen(word)+sizeof(char*)+1);
-			makemacro=(char**)*makemacro;
+			makemacro=(void*)*makemacro;
 			strcpy((char*)&makemacro[1],word);
 			++params;
 			eatchar(&src,',');
@@ -2701,7 +2702,7 @@ void expandmacro(label *id,char **next,int errline,char *errsrc) {
 	insidemacro++;
 	(*id).used=1;
 	snprintf(macroerr,WORDMAX*2,"%s(%i):%s",errsrc,errline,(*id).name);
-	line=(char**)((*id).line);
+	line=(void*)((*id).line);
 
 	//define macro params
 	s=*next;
@@ -2732,7 +2733,7 @@ void expandmacro(label *id,char **next,int errline,char *errsrc) {
 			if(arg<args) {			  //make named arg
 				addlabel((char*)&line[1],1);
 				equ(0,&s);
-				line=(char**)*line; //next arg name
+				line=(void*)*line; //next arg name
 			}
 			arg++;
 		}
@@ -2745,12 +2746,12 @@ void expandmacro(label *id,char **next,int errline,char *errsrc) {
 	//{..}
 
 	while(arg++ < args) //skip any unused arg names
-		line=(char**)*line;
+		line=(void*)*line;
 
 	while(line) {
 		linecount++;
 		processline((char*)&line[1],macroerr,linecount);
-		line=(char**)*line;
+		line=(void*)*line;
 	}
 	errmsg=0;
 	scope=oldscope;
@@ -2776,7 +2777,7 @@ void expandrept(int errline,char *errsrc) {
 	int linecount;
 	int i,oldscope;
 
-	start=(char**)repttext;//first rept data
+	start=(void*)repttext;//first rept data
 	oldscope=scope;
 	insidemacro++;
 	for(i=rept_loops;i;--i) {
@@ -2787,11 +2788,11 @@ void expandrept(int errline,char *errsrc) {
 		while(line) {
 			linecount++;
 			processline((char*)&line[1],macroerr,linecount);
-			line=(char**)*line;
+			line=(void*)*line;
 		}
 	}
 	while(start) {//delete everything
-		line=(char**)*start;
+		line=(void*)*start;
 		free(start);
 		start=line;
 	}


### PR DESCRIPTION
The below cast-align warnings are caused by `my_malloc()` returning a `static char *`, when in reality we probably just want `void *` as various functions use the allocated memory in various ways.  The force-casts used throughout things (ex. `(char**)`) are often wrong as well, which is what creates the warnings.  And while here, add the function prototype definition.

Examples:

```
asm6f.c:1480:12: error: cast from 'char *' to 'label **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
        labellist=(label**)my_malloc(INITLISTSIZE*sizeof(label*));
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
asm6f.c:1513:13: error: cast from 'char *' to 'comment **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
        comments = (comment**)my_malloc(commentcapacity * sizeof(comment*));
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
asm6f.c:1520:14: error: cast from 'char *' to 'comment **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
                comments = (comment**)my_malloc(commentcapacity * sizeof(comment*));
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
asm6f.c:1554:7: error: cast from 'char *' to 'comment *' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
                c = (comment*)my_malloc(sizeof(comment));
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
asm6f.c:1631:6: error: cast from 'char *' to 'label **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
        tmp=(label**)my_malloc(maxlabels*sizeof(label*));
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
asm6f.c:1646:4: error: cast from 'char *' to 'label *' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
        p=(label*)my_malloc(sizeof(label));
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
asm6f.c:1764:15: error: cast from 'char *' to 'char **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
                                makemacro=(char**)*makemacro;
                                          ^~~~~~~~~~~~~~~~~~
asm6f.c:1796:14: error: cast from 'char *' to 'char **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
                                makerept=(char**)*makerept;
                                         ^~~~~~~~~~~~~~~~~
asm6f.c:2668:14: error: cast from 'char *' to 'char **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
                        makemacro=(char**)*makemacro;
                                  ^~~~~~~~~~~~~~~~~~
asm6f.c:2704:7: error: cast from 'char *' to 'char **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
        line=(char**)((*id).line);
             ^~~~~~~~~~~~~~~~~~~~
asm6f.c:2735:10: error: cast from 'char *' to 'char **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
                                line=(char**)*line; //next arg name
                                     ^~~~~~~~~~~~~
asm6f.c:2748:8: error: cast from 'char *' to 'char **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
                line=(char**)*line;
                     ^~~~~~~~~~~~~
asm6f.c:2753:8: error: cast from 'char *' to 'char **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
                line=(char**)*line;
                     ^~~~~~~~~~~~~
asm6f.c:2779:8: error: cast from 'char *' to 'char **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
        start=(char**)repttext;//first rept data
              ^~~~~~~~~~~~~~~~
asm6f.c:2790:9: error: cast from 'char *' to 'char **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
                        line=(char**)*line;
                             ^~~~~~~~~~~~~
asm6f.c:2794:8: error: cast from 'char *' to 'char **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]
                line=(char**)*start;
                     ^~~~~~~~~~~~~~
```